### PR TITLE
fix member_login_check

### DIFF
--- a/shop/member_login_check.php
+++ b/shop/member_login_check.php
@@ -1,5 +1,6 @@
 <?php
 
+session_start(); // ユーザー認証は一番はじめに書かなければならない
 require_once('../common/common.php');
 
 try
@@ -16,7 +17,8 @@ try
   $dbh = new PDO($dsn, $user, $password);
   $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
   
-  $sql = 'SELECT code,m_name FROM dat_member WHERE m_email=? AND m_password=?';
+  // $sql = 'SELECT code,m_name FROM dat_member WHERE m_email=?';
+  $sql = 'SELECT code,m_name FROM dat_member WHERE m_password=? AND m_email=?';
   $stmt = $dbh->prepare($sql);
   $data[] = $member_pass;
   $data[] = $member_email;
@@ -34,10 +36,9 @@ try
   }
   else
   {
-    session_start(); // ユーザー認証
     $_SESSION['member_login'] = 1;
     $_SESSION['member_code'] = $rec['code'];
-    $_SESSION['member_name'] = $rec['name'];
+    $_SESSION['member_name'] = $rec['m_name'];
     header('Location: shop_list.php');
     exit();
   }

--- a/shop/order_form_done.php
+++ b/shop/order_form_done.php
@@ -28,11 +28,11 @@ $postal_code2 = $post['postal_code2'];
 $address = $post['address'];
 $tel = $post['tel'];
 $order = $post['order'];
-$password = $post['password'];
-// $password2 = $post['password2'];
+$pass = $post['password'];
 $gender = $post['gender'];
 $birth = $post['birth'];
 
+print_r ($post);
 print "${name}様、ご注文ありがとうございました！<br><br>";
 print "${email} にメールを送りましたので、ご確認ください。<br>";
 print "商品は以下の住所に発送させていただきます。<br><br>";
@@ -93,7 +93,7 @@ if($order == 'order_member')
   $stmt = $dbh->prepare($sql);
   $data = array();
   $data[] = $name;
-  $data[] = md5($password);
+  $data[] = md5($pass);
   $data[] = $email;
   $data[] = $postal_code1;
   $data[] = $postal_code2;

--- a/shop/shop_list.php
+++ b/shop/shop_list.php
@@ -10,7 +10,7 @@ if(isset($_SESSION['member_login'])==false)
 }
 else
 {
-  print 'ようこそ';
+  print 'ようこそ、';
   print $_SESSION['member_name'];
   print '様<br>';
   print '<a href="member_logout.php">ログアウト</a><br>';

--- a/staff_login/staff_login_check.php
+++ b/staff_login/staff_login_check.php
@@ -1,5 +1,6 @@
 <?php
 
+session_start(); // ユーザー認証は一番はじめに書かなければならない
 require_once('../common/common.php');
 
 try
@@ -8,9 +9,6 @@ try
   $staff_code = $post['code'];
   $staff_pass = $post['pass'];
 
-  // $staff_code = htmlspecialchars($staff_code,ENT_QUOTES,'UTF-8');
-  // $staff_pass = htmlspecialchars($staff_pass,ENT_QUOTES,'UTF-8');
-  
   $staff_pass = md5($staff_pass);
 
   $dsn = 'mysql:dbname=shop;host=localhost;charset=utf8';
@@ -36,7 +34,6 @@ try
   }
   else
   {
-    session_start(); // ユーザー認証
     $_SESSION['login'] = 1;
     $_SESSION['staff_code'] = $staff_code;
     $_SESSION['staff_name'] = $rec['name'];


### PR DESCRIPTION
# 注文を簡略化できる会員ログインの修正

## WHAT

- ログインできなかった問題を解決

配列の中身を確認したら値は入っているが、DBを確認すると `$password` が渡っていない。。  
で、変数をよく確認するとmysqlにログインするコード `$password='';` とダブっていたため、空の値がDBに渡っていた。
